### PR TITLE
Hide JuMP logo on small screens

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -46,12 +46,12 @@ $colour-notification-banner: #ffc107;
   }
 }
 
-// Only show logo on desktop.
+// Only show logo on tablets and larger.
 .home-page-logo {
-    display: none;
-    @include breakpoint(break-3) { // 1024px  ~ Desktop up
-      display: inline;
-    }
+  display: none;
+  @include breakpoint(break-2) { // 800px   ~ Large tablet up
+    display: inline;
+  }
 }
 
 // Dropdown nav

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -46,6 +46,14 @@ $colour-notification-banner: #ffc107;
   }
 }
 
+// Only show logo on desktop.
+.home-page-logo {
+    display: none;
+    @include breakpoint(break-3) { // 1024px  ~ Desktop up
+      display: inline;
+    }
+}
+
 // Dropdown nav
 .item--parent {
   color: $captionColour;

--- a/index.md
+++ b/index.md
@@ -1,7 +1,9 @@
 ---
 ---
 
-<img width="100%" src="/assets/jump-logo-with-text.svg">
+<div class="home-page-logo">
+    <img width="100%" src="/assets/jump-logo-with-text.svg">
+</div>
 
 **Welcome to the new website for JuMP. This site remains under construction as we transition from [juliaopt.org](http://juliaopt.org).**
 


### PR DESCRIPTION
I discussed with @mlubin hiding the logo on small screens. Here it is:

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/8177701/72686529-6a9a1680-3abb-11ea-93d6-8f9113aa2712.png">

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/8177701/72686530-74237e80-3abb-11ea-8505-17a0312b8c88.png">
