### PR TITLE
Indent bullets and reduce vertical whitespace

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,7 @@ navigation_header:
   url: /pages/code/
 - title: Documentation
   url: https://jump.dev/JuMP.jl/stable/
-- title: JuMP-dev Workshops
+- title: Workshops
   items:
    - title: 2020
      url: /meetings/louvain2020

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -51,8 +51,8 @@ $colour-notification-banner: #ffc107;
     margin-bottom: 0rem;
   }
   ul{
-    margin-left: 2em;
     margin-bottom: 0rem;
+    margin-left: 1em;
   }
 }
 

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -48,11 +48,11 @@ $colour-notification-banner: #ffc107;
 // Over-ride default indendation.
 :root {
   p{
-    margin-bottom: 0.5rem;
+    margin-bottom: 0rem;
   }
   ul{
     margin-left: 2em;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0rem;
   }
 }
 

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -45,6 +45,16 @@ $colour-notification-banner: #ffc107;
     font-size: 100%;
   }
 }
+// Over-ride default indendation.
+:root {
+  p{
+    margin-bottom: 0.5rem;
+  }
+  ul{
+    margin-left: 2em;
+    margin-bottom: 0.5rem;
+  }
+}
 
 // Only show logo on tablets and larger.
 .home-page-logo {


### PR DESCRIPTION
I found the whitespace to be excessive, and it annoyed me that the bullets were not indented.

Old on left, new on right.

<img width="100%" src="https://user-images.githubusercontent.com/8177701/96516528-d36d2400-12c3-11eb-9592-7c118a37c178.png">
