### PR TITLE
Fix navigation on mobile

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -45,13 +45,15 @@ $colour-notification-banner: #ffc107;
     font-size: 100%;
   }
 }
-// Over-ride default indendation.
+// Over-ride default indentation.
 :root {
   p{
     margin-bottom: 0rem;
   }
   ul{
-    margin-bottom: 0rem;
+    // TODO(odow): we should reduce the margin-bottom of lists, except this
+    // disables the drop-down navigation button on mobile.
+    // margin-bottom: 0rem;
     margin-left: 1em;
   }
 }


### PR DESCRIPTION
#32 broke the collapsible navigation menu on mobile (it stayed permanently open).

The margin below lists is bigger than `<p>`, but for some reason the burger menu doesn't work if we set this. I guess it sets `margin-bottom` somehow.

New layout:

<img width="972" alt="image" src="https://user-images.githubusercontent.com/8177701/96676285-78255980-13c9-11eb-8ca8-b974b1047b26.png">
