### PR TITLE
Add release post for JuMP v0.22

### DIFF
--- a/_posts/2021-11-04-release-0-22.md
+++ b/_posts/2021-11-04-release-0-22.md
@@ -102,7 +102,7 @@ syntax for specifing set inequalities. For example:
 # becomes
 @constraint(model, X >= Y, PSDCone())
 ```
-This works with any vector-valued cone, so that the following two are
+This works with any vector-valued cone (e.g., `SecondOrderCone()`), so that the following two are
 equivalent:
 ```julia
 @constraint(model, X - Y in SomeSet())

--- a/_posts/2021-11-04-release-0-22.md
+++ b/_posts/2021-11-04-release-0-22.md
@@ -121,7 +121,7 @@ Our next steps are:
  * Tag v1.0 releases of all the solver wrappers
  * Tag a JuMP v1.0 release!
 
-You can track our progress at [https://github.com/jump-dev/JuMP.jl/issues/2564](https://github.com/jump-dev/JuMP.jl/issues/2564). If you have encounter any issues with this release, please [open an issue](https://github.com/jump-dev/JuMP.jl/issues/new)
+You can track our progress at [https://github.com/jump-dev/JuMP.jl/issues/2564](https://github.com/jump-dev/JuMP.jl/issues/2564). If you encounter any issues with this release, please [open an issue](https://github.com/jump-dev/JuMP.jl/issues/new)
 or let us know over at the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev).
 
 Thanks to all who contributed to this release!

--- a/_posts/2021-11-04-release-0-22.md
+++ b/_posts/2021-11-04-release-0-22.md
@@ -1,0 +1,127 @@
+---
+layout: post
+title:  "JuMP 0.22 is released"
+date:   2021-11-04
+categories: [releases]
+permalink: /blog/0.22.0-release/
+---
+
+We're happy to announce the release of JuMP v0.22 and MathOptInterface v0.10,
+which completes a major milestone on our path to JuMP v1.0.
+
+Indeed, similar to how Julia v1.0 was Julia v0.7 with deprecations removed, we
+anticipate---barring unexpected problems---that JuMP v1.0 will be JuMP v0.22
+with deprecations removed.
+
+The release notes for [JuMP](https://jump.dev/JuMP.jl/dev/release_notes) and
+[MathOptInterface](https://jump.dev/MathOptInterface.jl/stable/release_notes/)
+contain a detailed list of the changes.
+
+For a full list of the merged pull requests and closed issues that contributed
+to this release, see the tag notes for [JuMP v0.22.0](https://github.com/jump-dev/JuMP.jl/releases/tag/v0.22.0)
+and [MathOptInterface v0.10.0](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v0.10.4).
+
+## Breaking changes
+
+JuMP v0.22 is a breaking release. However, the breaking changes should be
+invisible for the majority of users.
+
+There are four main areas of breakage:
+
+ * We have updated to MathOptInterface v0.10. If you used the MathOptInterface
+   API, things may have changed. See the [MathOptInterface release notes](https://jump.dev/MathOptInterface.jl/stable/release_notes/)
+   for details.
+ * Much of the JuMP-extension machinery has changed. This will only affect the
+   authors of JuMP extensions. We have contacted most authors directly to advise
+   them of the changes.
+ * The inner workings of `backend(model)` has changed. This will
+   only affect you if you accessed internal fields like `backend(model).model`.
+   The two main changes are:
+   * The backend is now a concrete type, instead of being a `CachingOptimizer`
+     with an `AbstractOptimizer` field.
+   * The cache is now  initialized in `EMPTY_OPTIMIZER` mode instead of
+     `ATTACHED_OPTIMIZER`.
+ * The `@SDconstraint` macro has been deprecated, but all usages can be replaced
+   by the new set inequality syntax. (More on this below.)
+
+## New features
+
+JuMP 0.22 has a range of new features, most of which are minor. Here is a
+summary of the more interesting ones.
+
+### Documentation as a PDF
+
+The documentation is now [available in PDF form](https://jump.dev/JuMP.jl/v0.22.0/JuMP.pdf)!
+
+Be warned: it's quite a big PDF, and some parts of the formatting need
+improving. However, we hope you find it useful. If you have suggestions for how
+the documentation could be improved, please [open a GitHub issue](https://github.com/jump-dev/JuMP.jl/issues/new)
+or join the [developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev).
+
+### Exported status codes
+
+Ever been annoyed at the fact you had to use the `MOI.` prefix in places like:
+```julia
+if termination_status(model) == MOI.OPTIMAL
+    # do stufff
+end
+```
+
+JuMP now re-exports `MOI.TerminationStatusCode` and `MOI.ResultStatusCode`, so
+you can use
+```julia
+import JuMP
+if JuMP.termination_status(model) == JuMP.OPTIMAL
+    # do stufff
+end
+```
+or
+```julia
+using JuMP
+if termination_status(model) == OPTIMAL
+    # do stufff
+end
+```
+
+Note that `JuMP.OPTIMAL === MOI.OPTIMAL`, so this is not a breaking change; all
+existing code will continue to work.
+
+### Set inequality syntax
+
+JuMP has long had support for specifying constraints about positive semidefinite
+(PSD) matrices. In versions prior to JuMP v0.22, there were two options to
+enforce  the constraint that the matrix `X - Y` was PSD:
+```julia
+@constraint(model, X -  Y in PSDCone())
+@SDconstraint(model, X >= Y)
+```
+JuMP v0.22 deprecates all usages of `@SDconstraint`,  introducing a more general
+syntax for specifing set inequalities. For example:
+```julia
+@SDconstraint(model, X >= Y)
+# becomes
+@constraint(model, X >= Y, PSDCone())
+```
+This works with any vector-valued cone, so that the following two are
+equivalent:
+```julia
+@constraint(model, X - Y in SomeSet())
+@constraint(model, X >= Y, SomeSet())
+```
+We think this provides a simpler interface for people modeling set inequalities,
+and one that more closely matches what they have written down on paper.
+
+## Next steps
+
+We're getting close to a release of JuMP v1.0.
+
+Our next steps are:
+ * Wait a while for people to use this release and report any bugs.
+ * Tag  a release of MathOptInterface v1.0
+ * Tag v1.0 releases of all the solver wrappers
+ * Tag a JuMP v1.0 release!
+
+You can track our progress at [https://github.com/jump-dev/JuMP.jl/issues/2564](https://github.com/jump-dev/JuMP.jl/issues/2564). If you have encounter any issues with this release, please [open an issue](https://github.com/jump-dev/JuMP.jl/issues/new)
+or let us know over at the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev).
+
+Thanks to all who contributed to this release!

--- a/_posts/2021-11-10-release-0-22.md
+++ b/_posts/2021-11-10-release-0-22.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "JuMP 0.22 is released"
-date:   2021-11-04
+date:   2021-11-10
 categories: [releases]
 permalink: /blog/0.22.0-release/
 ---


### PR DESCRIPTION
Prepping for a release of JuMP v0.22:

TODOs before merging:

 - [x] Update the JuMP README with the new version information
 - [x] Create a `release-0.22` branch
 - [x] Tag a new release
 - [x] Publish this post