### PR TITLE
Add a page for upcoming events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,8 +115,12 @@ navigation_header:
   url: https://jump.dev/JuMP.jl/stable/
 - title: Community
   items:
+  - title: Calendar
+    url: /pages/calendar
   - title: Forum
     url: https://discourse.julialang.org/c/domain/opt
+  - title: Chatroom
+    url: https://gitter.im/JuliaOpt/JuMP-dev
   - title: Ecosystem
     url: /pages/code/
 - title: Workshops

--- a/index.md
+++ b/index.md
@@ -35,6 +35,16 @@ the book,
 which covers a variety of topics on optimization, with an emphasis on solving
 practical problems using JuMP and Julia.
 
+## Get involved
+
+Here are some things you can do to become more involved in the JuMP community:
+
+ * Help answer questions on the [community forum](https://discourse.julialang.org/c/domain/opt/13)
+ * Read the [contributing guide](https://jump.dev/JuMP.jl/stable/developers/contributing/)
+ * Read about our [governance structure](/pages/governance)
+ * Join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+ * Attend [upcoming events](/pages/calendar)
+
 ## See also
 
 The JuMP ecosystem includes [Convex.jl](https://github.com/jump-dev/Convex.jl),

--- a/pages/calendar.md
+++ b/pages/calendar.md
@@ -1,0 +1,16 @@
+---
+title:  "Upcoming meetings and events"
+---
+
+This page collates upcoming events related to JuMP.
+
+## Regularly scheduled calls
+
+ * There is a monthly JuMP developers call on the fourth Thursday of each month
+   at 14:00 Eastern time. The call is open to all community members. For a
+   calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+   and tag `@odow`.
+ * There is an infrequently scheduled call focused on nonlinear programming. We
+   intend to hold this more regularly in 2022. For a
+   calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+   and tag `@frapac`.

--- a/pages/calendar.md
+++ b/pages/calendar.md
@@ -1,5 +1,5 @@
 ---
-title:  "Upcoming meetings and events"
+title:  "Meetings and events"
 ---
 
 This page collates upcoming events related to JuMP.
@@ -9,8 +9,14 @@ This page collates upcoming events related to JuMP.
  * There is a monthly JuMP developers call on the fourth Thursday of each month
    at 14:00 Eastern time. The call is open to all community members. For a
    calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
-   and tag `@odow`.
- * There is an infrequently scheduled call focused on nonlinear programming. We
-   intend to hold this more regularly in 2022. For a
+   and ask `@odow` for an invite.
+ * There is a montly call focused on nonlinear programming on the second
+   Wednesday of each month. The call is open to all community members. For a
    calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
-   and tag `@frapac`.
+   and ask `@frapac` for an invite.
+
+## JuMP at conferences
+
+ * Miles Lubin and Benoît Legat will host a workshop on JuMP at the
+   [2022 ICCOPT summer school](https://iccopt2022.lehigh.edu/summer-school/summer-school-program/),
+   to be held July 24, 2022.


### PR DESCRIPTION
We should flesh this out whenever JuMP speakers attend conferences etc.