### PR TITLE
Add schedule for JuMP-dev talks

### DIFF
--- a/_posts/2022-01-31-jump_dev_2022.md
+++ b/_posts/2022-01-31-jump_dev_2022.md
@@ -25,34 +25,48 @@ JuliaCon 2022 is entirely virtual and free to attend, but
 
 All participants will uphold the [JuliaCon Code of Conduct](https://juliacon.org/2022/coc/).
 
-## How do I give a talk?
+## Schedule
 
-**Talk submission has now closed**
+All talks at JuMP-dev will be played live on Youtube at the times below.
+[Register for JuliaCon](https://juliacon.org/2022/tickets/) to receive a link
+and instructions for how to watch. After the event, we will replace the "Time"
+column with links to the recorded videos.
 
-Similarly to [previous](/meetings/mit2017) [iterations](/meetings/bordeaux2018)
-[of the](/meetings/santiago2019) [workshop](/meetings/juliacon2021), we invite
-participants to present work related to JuMP. In particular, we especially seek
-talks related to:
-
-- JuMP core development ([MathOptInterface](https://github.com/JuliaOpt/MathOptInterface.jl), JuMP 1.0)
-- Mathematical optimization solvers written in Julia
-- Automatic differentiation in Julia (e.g., Cassette, Zygote)
-- Julia interfaces to mathematical optimization solvers
-- JuMP extensions (stochastic programming, robust optimization, multiobjective optimization, ...)
-- Software that uses JuMP
-- Developer tools for JuMP
-- Commercial use of JuMP
-- Uses of JuMP in teaching
-
-Speakers are encouraged to highlight challenges and lessons learned, not only
-successes. Talks should be aimed at a general audience, but familiarity with
-JuMP/Julia can be assumed.
-
-See the previous workshops for examples of accepted talks:
- * [2017](/meetings/mit2017/)
- * [2018](/meetings/bordeaux2018/)
- * [2019](/meetings/santiago2019)
- * [2021](/meetings/juliacon2021).
+| **Title**                                                 | **Speaker**        | **Time (UTC)** |
+| --------------------------------------------------------- | ------------------ | -------------- |
+| **July 27** |
+| UnitJuMP: Automatic unit handling in JuMP	                | Truls Flatberg     | 12:30 |
+| SparseVariables - Efficient sparse modelling with JuMP    | Lars Hellemo       | 12:40 |
+| JuMP ToQUBO Automatic Reformulation	                    | Pedro Xavier       | 12:50 |
+| A multi-precision algorithm for convex quadratic optimization	| Geoffroy Leconte | 13:00 |
+| Interior-point conic optimization with Clarabel.jl	    | Paul Goulart       | 13:30 |
+|                                                           |                    | **break** |
+| JuMP 1.0: What you need to know	                        | Miles Lubin        | 14:30 |
+| A user’s perspective on using JuMP in an academic project	| Mathieu Tanneau    | 15:00 |
+| COPT and its Julia interface	                            | Qi Huangfu         | 15:30 |
+| JuMP and HiGHS: the best open-source linear optimization solvers | Julian Hall | 15:40 |
+|                                                           |                    | **break** |
+| Pajarito's MathOptInterface makeover	                    | Chris Coey         | 19:00 |
+| A matrix-free fix-propagate-and-project heuristic for MILPs | Mathieu Besançon | 19:30 |
+| Verifying Inverse Model Neural Networks Using JuMP	    | Chelsea Sidrane    | 20:10 |
+| Complex number support in JuMP	                        | Benoît Legat       | 20:00 |
+| **July 29** |
+| Improving nonlinear programming support in JuMP	        | Oscar Dowson       | 16:30 |
+| Benchmarking Nonlinear Optimization with AC Optimal Power Flow  | Carleton Coffrin | 17:00 |
+| Advances in Transformations and NLP Modeling for InfiniteOpt.jl |	Joshua Pulsipher | 17:30 |
+|                                                           |                    | **break** |
+| The JuliaSmoothOptimizers (JSO) Organization	            | Dominique Orban    | 19:00 |
+| PDE-constrained optimization using JuliaSmoothOptimizers	| Tangi Migot        | 19:30 |
+| Generalized Disjunctive Programming via DisjunctiveProgramming | Hector D. Perez | 20:00 |
+| **July 29** |
+| DiffOpt.jl differentiating your favorite optimization problems | Joaquim Dias Garcia | 16:30 |
+| Recent developments in ParametricOptInterface.jl	        | Guilherme Bodin    | 17:00 |
+| Stochastic Optimal Control with MarkovBounds.jl	        | Flemming Holtorf   | 17:10 |
+| Optimising Fantasy Football with JuMP	                    | Dean Markwick      | 17:20 |
+| Risk Budgeting Portfolios from simulations | Bernardo Freitas Paulo da Costa   | 17:30 |
+|                                                           |                    | **break** |
+| Streamlining nonlinear programming on GPUs      | François Pacaud and Michel Schanen | 19:00 |
+| Fast optimization via randomized numerical linear algebra	| Theo Diamandis     | 19:30 |
 
 ## Program committee
 

--- a/_posts/2022-01-31-jump_dev_2022.md
+++ b/_posts/2022-01-31-jump_dev_2022.md
@@ -32,6 +32,9 @@ All talks at JuMP-dev will be played live on Youtube at the times below.
 and instructions for how to watch. After the event, we will replace the "Time"
 column with links to the recorded videos.
 
+Note that these times are subject to change. See [the JuliaCon schedule](https://live.juliacon.org/agenda)
+for the definitive schedule.
+
 | **Title**                                                 | **Speaker**        | **Time (UTC)** |
 | --------------------------------------------------------- | ------------------ | -------------- |
 | **July 27** |


### PR DESCRIPTION
This is still subject to change, but I can update if the Pretalx schedule changes.

<img width="942" alt="image" src="https://user-images.githubusercontent.com/8177701/179122008-40374690-f87c-4cfe-b0b5-42aae5310a24.png">
