### PR TITLE
Add initial announcement for JuMP-dev 2023

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -165,4 +165,4 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
 
 # Site header notification content
 notification: |
- Submit talks for [JuMP-dev 2023](/meetings/jump-dev-2023/)
+ Submit a talk for [JuMP-dev 2023](/meetings/jumpdev2023/)

--- a/_config.yml
+++ b/_config.yml
@@ -127,6 +127,8 @@ navigation_header:
     url: /pages/code/
 - title: Workshops
   items:
+   - title: 2023
+     url: /meetings/jumpdev2023
    - title: 2022
      url: /meetings/juliacon2022
    - title: 2021
@@ -162,5 +164,5 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
   Email: true
 
 # Site header notification content
-# notification: |
-#  [JuMP-dev 2022](/meetings/juliacon2022/) will be co-located with JuliaCon, July 27-29 2022.
+notification: |
+ Submit talks for [JuMP-dev 2023](/meetings/jump-dev-2023/)

--- a/_posts/2022-11-20-jump_dev_2023.md
+++ b/_posts/2022-11-20-jump_dev_2023.md
@@ -1,0 +1,59 @@
+---
+layout: page
+title:  "JuMP-dev 2023"
+date:   2022-11-20
+categories: [jump-dev]
+permalink: /meetings/jumpdev2023/
+---
+
+The JuMP steering committee is still confirming the details of JuMP-dev 2023.
+
+It will **either** be co-located with JuliaCon 2023, **or** it will be a
+standalone event in late June.
+
+ * If we co-locate JuMP-dev with JuliaCon, JuMP-dev will run as an in-person track
+   of JuliaCon. This year, JuliaCon is being held 24-29 July, 2023 in Cambridge,
+   Massachusetts. You can find more information on the [conference website](https://juliacon.org/2023/).
+ * If we run a standalone event, it will likely by held 24-25 June, 2023 in Madison,
+   Wisconsin, following [IPCO2023](https://optimization.discovery.wisc.edu/ipco-2023-madison/).
+
+While we sort the logistical details, if you wish to give a talk at JuMP-dev
+2023, please [submit a proposal to JuliaCon](https://pretalx.com/juliacon2023/cfp).
+For "Session type," choose "Talk" or "Lightning talk." For "Track," choose
+"JuMP."
+
+ * If we co-locate with JuliaCon, you will need to register for JuliaCon.
+ * If we run a standalone event, we will give speakers the option of
+   transferring their talk to the standalone JuMP-dev, or continuing with a talk
+   at JuliaCon.
+
+## How do I give a talk?
+
+**To give a talk, [submit a proposal to JuliaCon](https://pretalx.com/juliacon2023/cfp)**
+**For "Session type," choose "Talk" or "Lightning talk." For "Track," choose**
+**"JuMP."**
+
+Similarly to [previous](/meetings/mit2017) [iterations](/meetings/bordeaux2018)
+[of](/meetings/santiago2019) [the](/meetings/juliacon2021) [workshop](/meetings/juliacon2022),
+we invite participants to present work related to JuMP. In particular, we
+especially seek talks related to:
+
+- JuMP core development ([MathOptInterface](https://github.com/JuliaOpt/MathOptInterface.jl), JuMP 1.0)
+- Mathematical optimization solvers written in Julia
+- Automatic differentiation in Julia
+- Julia interfaces to mathematical optimization solvers
+- JuMP extensions (stochastic programming, robust optimization, multiobjective optimization, ...)
+- Software that uses JuMP
+- Developer tools for JuMP
+- Commercial use of JuMP
+- Uses of JuMP in teaching
+
+Speakers are encouraged to highlight challenges and lessons learned, not only
+successes. Talks should be aimed at a general audience, but familiarity with
+JuMP/Julia can be assumed.
+
+See the previous workshops for examples of accepted talks: [2017](/meetings/mit2017/),
+[2018](/meetings/bordeaux2018/), [2019](/meetings/santiago2019),
+[2021](/meetings/juliacon2021), and [2022](/meetings/juliacon2022).
+
+To contact the program committee, write to [jump-dev-2023@googlegroups.com](mailto:jump-dev-2023@googlegroups.com).

--- a/_posts/2022-11-20-jump_dev_2023.md
+++ b/_posts/2022-11-20-jump_dev_2023.md
@@ -6,26 +6,25 @@ categories: [jump-dev]
 permalink: /meetings/jumpdev2023/
 ---
 
-The JuMP steering committee is still confirming the details of JuMP-dev 2023.
+We are pleased to announce that JuMP-dev 2023 will be co-located with
+[JuliaCon 2023](https://juliacon.org/2023)!
 
-It will **either** be co-located with JuliaCon 2023, **or** it will be a
-standalone event in late June.
+This year, JuliaCon is being held 24-29 July, 2023 in Cambridge, Massachusetts.
+You can find more information on the [conference website](https://juliacon.org/2023/).
 
- * If we co-locate JuMP-dev with JuliaCon, JuMP-dev will run as an in-person track
-   of JuliaCon. This year, JuliaCon is being held 24-29 July, 2023 in Cambridge,
-   Massachusetts. You can find more information on the [conference website](https://juliacon.org/2023/).
- * If we run a standalone event, it will likely by held 24-25 June, 2023 in Madison,
-   Wisconsin, following [IPCO2023](https://optimization.discovery.wisc.edu/ipco-2023-madison/).
+## Outline
 
-While we sort the logistical details, if you wish to give a talk at JuMP-dev
-2023, please [submit a proposal to JuliaCon](https://pretalx.com/juliacon2023/cfp).
-For "Session type," choose "Talk" or "Lightning talk." For "Track," choose
-"JuMP."
+The purpose of JuMP-dev is to bring together students, researchers, and
+practitioners with interests in the methodological, algorithmic, and software aspects of
+[JuMP](https://github.com/jump-dev/JuMP.jl) and related packages. In particular,
+we invite new contributors and those who have not met the core development team.
 
- * If we co-locate with JuliaCon, you will need to register for JuliaCon.
- * If we run a standalone event, we will give speakers the option of
-   transferring their talk to the standalone JuMP-dev, or continuing with a talk
-   at JuliaCon.
+## How do I attend?
+
+To attend JuMP-dev, you must purchase a ticket to JuliaCon 2023. Ticket sales
+will open in early 2023.
+
+All participants will uphold the [JuliaCon Code of Conduct](https://juliacon.org/2023/coc/).
 
 ## How do I give a talk?
 
@@ -55,5 +54,13 @@ JuMP/Julia can be assumed.
 See the previous workshops for examples of accepted talks: [2017](/meetings/mit2017/),
 [2018](/meetings/bordeaux2018/), [2019](/meetings/santiago2019),
 [2021](/meetings/juliacon2021), and [2022](/meetings/juliacon2022).
+
+## Programme committee
+
+ * Oscar Dowson
+ * Joaquim Dias Garcia (PSR)
+ * Benoît Legat (MIT)
+ * Miles Lubin (HRT)
+ * Joshua Pulsipher (CMU)
 
 To contact the program committee, write to [jump-dev-2023@googlegroups.com](mailto:jump-dev-2023@googlegroups.com).

--- a/_posts/2022-11-20-jump_dev_2023.md
+++ b/_posts/2022-11-20-jump_dev_2023.md
@@ -9,7 +9,7 @@ permalink: /meetings/jumpdev2023/
 We are pleased to announce that JuMP-dev 2023 will be co-located with
 [JuliaCon 2023](https://juliacon.org/2023)!
 
-This year, JuliaCon is being held 24-29 July, 2023 in Cambridge, Massachusetts.
+This year, JuliaCon is being held in person, 24-29 July, 2023 in Cambridge, Massachusetts.
 You can find more information on the [conference website](https://juliacon.org/2023/).
 
 ## Outline
@@ -64,4 +64,4 @@ See the previous workshops for examples of accepted talks: [2017](/meetings/mit2
  * Miles Lubin (HRT)
  * Joshua Pulsipher (CMU)
 
-To contact the program committee, write to [jump-dev-2023@googlegroups.com](mailto:jump-dev-2023@googlegroups.com).
+To contact the program committee, write to `jump-dev-2023@googlegroups.com`.

--- a/_posts/2022-11-20-jump_dev_2023.md
+++ b/_posts/2022-11-20-jump_dev_2023.md
@@ -58,10 +58,13 @@ See the previous workshops for examples of accepted talks: [2017](/meetings/mit2
 ## Programme committee
 
  * Oscar Dowson
+ * Mathieu Besançon (ZIB)
  * Chris Coey (RAI)
+ * Theo Diamandis (MIT)
  * Joaquim Dias Garcia (PSR)
- * Benoît Legat (MIT)
+ * Benoît Legat (KU Leuven)
  * Miles Lubin (HRT)
+ * François Pacaud (Mines Paris)
  * Joshua Pulsipher (CMU)
 
 To contact the program committee, write to `jump-dev-2023@googlegroups.com`.

--- a/_posts/2022-11-20-jump_dev_2023.md
+++ b/_posts/2022-11-20-jump_dev_2023.md
@@ -58,6 +58,7 @@ See the previous workshops for examples of accepted talks: [2017](/meetings/mit2
 ## Programme committee
 
  * Oscar Dowson
+ * Chris Coey (RAI)
  * Joaquim Dias Garcia (PSR)
  * Benoît Legat (MIT)
  * Miles Lubin (HRT)


### PR DESCRIPTION
We're getting a little squeezed for time because JuliaCon brought all of the dates forward to help people get visas in time. We can probably get an extension, or run a separate CFP if we run a separate event.

We also need a program committee, but I'll post on the Gitter once this is up.