### PR TITLE
Change chatroom to Julia slack, and add /forum and /chatroom links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,9 +120,9 @@ navigation_header:
   - title: Calendar
     url: /pages/calendar
   - title: Forum
-    url: https://discourse.julialang.org/c/domain/opt
+    url: /forum
   - title: Chatroom
-    url: https://gitter.im/JuliaOpt/JuMP-dev
+    url: /chatroom
   - title: Ecosystem
     url: /pages/code/
 - title: Workshops

--- a/_posts/2020-09-21-release-0-21-5.md
+++ b/_posts/2020-09-21-release-0-21-5.md
@@ -10,7 +10,7 @@ We are happy to announce the joint release of JuMP 0.21.5 and MathOptInterface
 0.9.17! These releases are a mix of new features and some much needed
 performance optimizations. This should be a non-breaking release, please let us
 know if this isn't the case by [opening a Github issue](https://github.com/jump-dev/JuMP.jl/issues/new/choose)
-or joining the [Gitter chat](https://gitter.im/JuliaOpt/JuMP-dev). We did have
+or joining the [Developer chatroom](/chatroom). We did have
 a couple of bugs that slipped into a short-lived release, hence the jump (if you
 will excuse us) from 0.21.3 to 0.21.5.
 

--- a/_posts/2021-01-28-release-0-21-6.md
+++ b/_posts/2021-01-28-release-0-21-6.md
@@ -9,7 +9,7 @@ permalink: /blog/0.21.6-release/
 We are happy to announce the release of JuMP 0.21.6. This should be a
 non-breaking release, please let us know if this isn't the case by
 [opening a Github issue](https://github.com/jump-dev/JuMP.jl/issues/new/choose)
-or joining the [developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev).
+or joining the [developer chatroom](/chatroom).
 
 A key feature of interest is that we have significantly revised our
 documentation, including [examples that are now built in the documentation](https://jump.dev/JuMP.jl/v0.21.6/examples/basic/).

--- a/_posts/2021-04-12-release-0-21-7.md
+++ b/_posts/2021-04-12-release-0-21-7.md
@@ -9,12 +9,12 @@ permalink: /blog/0.21.7-release/
 We are happy to announce the release of JuMP 0.21.7. This should be a
 non-breaking release, please let us know if this isn't the case by
 [opening a Github issue](https://github.com/jump-dev/JuMP.jl/issues/new/choose)
-or joining the [developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev).
+or joining the [developer chatroom](/chatroom).
 
 A key feature of interest is that we have continued to significantly revise our
-documentation. The [Nonlinear Modeling](https://jump.dev/JuMP.jl/v0.21.7/manual/nlp/#Nonlinear-Modeling) 
+documentation. The [Nonlinear Modeling](https://jump.dev/JuMP.jl/v0.21.7/manual/nlp/#Nonlinear-Modeling)
 section is now much clearer, and there are now [integrated tutorials](https://jump.dev/JuMP.jl/v0.21.7/tutorials/Getting%20started/an_introduction_to_julia/).
-If you have suggestions for how things could be further improved, please reach 
+If you have suggestions for how things could be further improved, please reach
 out.
 
 A summary of changes are as follows:
@@ -73,7 +73,7 @@ For a full list of the merged pull requests and closed issues that contributed
 to this release, see the tag notes for [JuMP v0.21.7](https://github.com/jump-dev/JuMP.jl/releases/tag/v0.21.7).
 
 This release knocks out a number of major items on our
-[roadmap](https://jump.dev/JuMP.jl/v0.21.7/developers/roadmap/) for JuMP 1.0. 
+[roadmap](https://jump.dev/JuMP.jl/v0.21.7/developers/roadmap/) for JuMP 1.0.
 (We're getting close!)
 
 Stay tuned for more progress!

--- a/_posts/2022-03-24-jump-1.0.md
+++ b/_posts/2022-03-24-jump-1.0.md
@@ -112,8 +112,8 @@ of Julia will be updated and a new minor release will be tagged.
 JuMP 1.0 is not an end goal. We have big plans for the future! To get involved:
 
  * Read our [roadmap](https://jump.dev/JuMP.jl/stable/developers/roadmap/)
- * Join the [community forum](https://discourse.julialang.org/c/domain/opt/13)
- * Join the [developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev)
+ * Join the [community forum](/forum)
+ * Join the [developer chatroom](/chatroom)
 
 ## Thank you
 

--- a/chatroom.md
+++ b/chatroom.md
@@ -1,0 +1,9 @@
+---
+title:  "Developer chatroom"
+---
+
+JuMP uses the `#jump-dev` channel of the Julia community slack to discuss
+developer-related aspects of JuMP.
+
+Join the Julia community slack by following the link and instructons at
+[https://julialang.org/slack/](https://julialang.org/slack/).

--- a/forum.html
+++ b/forum.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Forum</title>
+<link rel="canonical" href="https://discourse.julialang.org/c/domain/opt/13">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://discourse.julialang.org/c/domain/opt/13">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://discourse.julialang.org/c/domain/opt/13");
+</script>
+</head>
+<body>
+If you are not redirected automatically, click <a href="https://discourse.julialang.org/c/domain/opt/13">here</a>.
+</body>
+</html>

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ even [optimize milk output](https://juliacomputing.com/case-studies/moo/).
  * Install JuMP and Julia by reading the [Installation Guide](https://jump.dev/JuMP.jl/stable/installation/)
  * Learn Julia by reading [Getting started with Julia](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/getting_started_with_julia/)
  * Solve your first JuMP model by reading [Getting started with JuMP](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/getting_started_with_JuMP/)
- * Get help by joining the [community forum](https://discourse.julialang.org/c/domain/opt/13)
+ * Get help by joining the [community forum](/forum)
   to search for answers to commonly asked questions.
 
 There is a growing collection of third-party materials about JuMP. This includes
@@ -39,11 +39,11 @@ practical problems using JuMP and Julia.
 
 Here are some things you can do to become more involved in the JuMP community:
 
- * Help answer questions on the [community forum](https://discourse.julialang.org/c/domain/opt/13)
+ * Help answer questions on the [community forum](/forum)
  * Star and watch the [repository](https://github.com/jump-dev/JuMP.jl)
  * Read the [contributing guide](https://jump.dev/JuMP.jl/stable/developers/contributing/)
  * Read about our [governance structure](/pages/governance)
- * Join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+ * Join the [developer chatroom](/chatroom)
  * Attend [upcoming events](/pages/calendar)
 
 ## See also

--- a/pages/calendar.md
+++ b/pages/calendar.md
@@ -8,11 +8,11 @@ This page collates upcoming events related to JuMP.
 
  * There is a monthly JuMP developers call on the fourth Thursday of each month
    at 14:00 Eastern time. The call is open to all community members. For a
-   calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+   calendar invite and access to the Zoom link, join the [developer chatroom](/chatroom)
    and ask `@odow` for an invite.
  * There is a montly call focused on nonlinear programming on the second
    Wednesday of each month. The call is open to all community members. For a
-   calendar invite and access to the Zoom link, join the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev)
+   calendar invite and access to the Zoom link, join the [developer chatroom](/chatroom)
    and ask `@frapac` for an invite.
 
 ## JuMP at conferences

--- a/pages/governance.md
+++ b/pages/governance.md
@@ -221,14 +221,14 @@ The community forum is a place for community members to post questions and
 receive help.
 
 The current forum is the ["Optimization (Mathematical)" section of the
-Julia Discourse Forum](https://discourse.julialang.org/c/domain/opt/13).
+Julia Discourse Forum](/forum).
 
 ### Developer Chatroom
 
 The developer chatroom is a chatroom for developer-focused discussions about
 JuMP.
 
-The current chatroom is the [JuMP-dev Gitter channel](https://gitter.im/JuliaOpt/JuMP-dev).
+The current chatroom is the [`#jump-dev` channel of the Julia slack](/chatroom).
 
 ### Monthly Developer Call
 


### PR DESCRIPTION
The new links will enable other places to easily link to the forum and chatroom, and allow us to update them in future to new locations.

Tested redirects locally.

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/8177701/235014578-ff056fb5-3a51-496b-8341-f22cddc43bfe.png">
