### PR TITLE
Add page for JuMP-dev 2024

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -127,6 +127,8 @@ navigation_header:
     url: /pages/code/
 - title: Workshops
   items:
+   - title: 2024
+     url: /meetings/jumpdev2024
    - title: 2023
      url: /meetings/jumpdev2023
    - title: 2022
@@ -164,5 +166,5 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
   Email: true
 
 # Site header notification content
-# notification: |
-#  [Attend JuMP-dev 2023, July 27-29 in Cambridge, MA](/meetings/jumpdev2023/)
+notification: |
+ [JuMP-dev 2024 will be held July 19-21 in Montreal, Canada](/meetings/jumpdev2024/)

--- a/_config.yml
+++ b/_config.yml
@@ -167,4 +167,4 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
 
 # Site header notification content
 notification: |
- [JuMP-dev 2024 will be held July 19-21 in Montreal, Canada](/meetings/jumpdev2024/)
+ [JuMP-dev 2024 will be held July 19-21 in Montréal, Canada](/meetings/jumpdev2024/)

--- a/_posts/2023-10-22-jump_dev_2024.md
+++ b/_posts/2023-10-22-jump_dev_2024.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title:  "JuMP-dev 2024"
+date:   2023-10-23
+categories: [jump-dev]
+permalink: /meetings/jumpdev2024/
+---
+
+**[Submit a talk for JuMP-dev 2024](https://forms.gle/R5WXwGSkYKjYhYVg9)**
+
+JuMP-dev 2024 will be held 19-21 July, 2024 in Montreal, Canada. This is
+immediately prior to [ISMP 2024](https://ismp2024.gerad.ca).
+
+## Outline
+
+The purpose of JuMP-dev is to bring together students, researchers, and
+practitioners with interests in the methodological, algorithmic, and software
+aspects of [JuMP](https://github.com/jump-dev/JuMP.jl) and related packages. In
+particular, we invite new contributors and those who have not met the core
+development team.
+
+## How do I attend?
+
+To attend JuMP-dev, you must purchase a ticket. Ticket sales will open in early 2024.
+Accepted speakers at JuMP-dev will receive a free ticket.
+
+You do not need a ticket to ISMP to attend JuMP-dev.
+
+All participants will uphold the [JuliaCon Code of Conduct](https://juliacon.org/2023/coc/).
+
+## How do I give a talk?
+
+Similarly to previous years, we invite participants to present work related
+to JuMP.
+
+Talk submissions are now open, and they will close on January 31, 2024. Accepted
+talks will be notified in mid-February, 2024.
+
+**[Submit a talk for JuMP-dev 2024](https://forms.gle/R5WXwGSkYKjYhYVg9)**
+
+We especially seek talks about JuMP applications and providing feedback on the
+user-experience of using JuMP in industry and teaching.
+
+Speakers are encouraged to highlight the challenges faced and lessons learned,
+not only successes. Talks should be aimed at a general audience, but familiarity
+with JuMP/Julia can be assumed.
+
+If you have an idea for a talk and are not sure if it will be of interest, ask
+the program committee by writing to `jump-dev-2024@googlegroups.com`.
+
+See the previous workshops for examples of accepted talks:
+[2017](/meetings/mit2017),
+[2018](/meetings/bordeaux2018),
+[2019](/meetings/santiago2019),
+[2021](/meetings/juliacon2021),
+[2022](/meetings/juliacon2022),
+[2023](/meetings/juliacon2023).
+
+## Venue
+
+JuMP-dev will be located in the [GERAD building](https://maps.app.goo.gl/4ZW5TfudZDgue32E6)
+at the University of Montreal.
+
+## Programme committee
+
+ * Oscar Dowson
+ * Joaquim Dias Garcia (PSR)
+ * Benoît Legat (KU Leuven)
+ * Miles Lubin (HRT)
+
+To contact the program committee, write to `jump-dev-2024@googlegroups.com`.

--- a/_posts/2023-10-22-jump_dev_2024.md
+++ b/_posts/2023-10-22-jump_dev_2024.md
@@ -26,7 +26,7 @@ Accepted speakers at JuMP-dev will receive a free ticket.
 
 You do not need a ticket to ISMP to attend JuMP-dev.
 
-All participants will uphold the [JuliaCon Code of Conduct](https://juliacon.org/2023/coc/).
+All participants will uphold the [JuMP Code of Conduct](https://github.com/jump-dev/JuMP.jl/blob/master/CODE_OF_CONDUCT.md).
 
 ## How do I give a talk?
 

--- a/_posts/2023-10-22-jump_dev_2024.md
+++ b/_posts/2023-10-22-jump_dev_2024.md
@@ -72,5 +72,6 @@ JuMP-dev will be hosted by [GERAD](https://www.gerad.ca/en), located in the
  * Miles Lubin (HRT)
  * Alexis Montoison (GERAD; local organization)
  * Dominique Orban (GERAD; local organization)
- 
+ * Joshua Pulsipher (UWaterloo)
+
 To contact the program committee, write to `jump-dev-2024@googlegroups.com`.

--- a/_posts/2023-10-22-jump_dev_2024.md
+++ b/_posts/2023-10-22-jump_dev_2024.md
@@ -8,7 +8,7 @@ permalink: /meetings/jumpdev2024/
 
 **[Submit a talk for JuMP-dev 2024](https://forms.gle/R5WXwGSkYKjYhYVg9)**
 
-JuMP-dev 2024 will be held 19-21 July, 2024 in Montreal, Canada. This is
+JuMP-dev 2024 will be held 19-21 July, 2024 in Montréal, Canada. This is
 immediately prior to [ISMP 2024](https://ismp2024.gerad.ca).
 
 ## Outline
@@ -58,14 +58,19 @@ See the previous workshops for examples of accepted talks:
 
 ## Venue
 
-JuMP-dev will be located in the [GERAD building](https://maps.app.goo.gl/4ZW5TfudZDgue32E6)
-at the University of Montreal.
+JuMP-dev will be hosted by [GERAD](https://www.gerad.ca/en), located in the
+[GERAD building](https://maps.app.goo.gl/4ZW5TfudZDgue32E6).
 
 ## Programme committee
 
  * Oscar Dowson
+ * David Bernal Neira (Purdue)
+ * Theo Diamandis (MIT)
  * Joaquim Dias Garcia (PSR)
+ * James Foster (CSIRO)
  * Benoît Legat (KU Leuven)
  * Miles Lubin (HRT)
-
+ * Alexis Montoison (GERAD; local organization)
+ * Dominique Orban (GERAD; local organization)
+ 
 To contact the program committee, write to `jump-dev-2024@googlegroups.com`.

--- a/_posts/2023-10-22-jump_dev_2024.md
+++ b/_posts/2023-10-22-jump_dev_2024.md
@@ -61,7 +61,7 @@ See the previous workshops for examples of accepted talks:
 JuMP-dev will be hosted by [GERAD](https://www.gerad.ca/en), located in the
 [GERAD building](https://maps.app.goo.gl/4ZW5TfudZDgue32E6).
 
-## Programme committee
+## Program committee
 
  * Oscar Dowson
  * David Bernal Neira (Purdue)


### PR DESCRIPTION
I don't know if we've confirmed the 21st, but it seems safe to start announcing this. The details of the 21st can be changed later once the exact schedule for ISMP is locked in.

We also need some other program committee members (comment if anyone reading this is interested), but we can discuss via email.