### PR TITLE
Fix link for GAMS blogpost

### DIFF
--- a/_posts/2023-07-20-gams-blog.md
+++ b/_posts/2023-07-20-gams-blog.md
@@ -5,6 +5,9 @@ date: 2023-07-20
 categories: [general]
 author: "Miles Lubin, Oscar Dowson, Joaquim Dias Garcia, Joey
 Huchette, Benoît Legat"
+# permalink neeeded because @odow added the `general` category _after_ this had
+# already been published and linked.
+permalink: /2023/07/20/gams-blog/
 ---
 
 A [recent blog post](https://www.gams.com/blog/2023/07/performance-in-optimization-models-a-comparative-analysis-of-gams-pyomo-gurobipy-and-jump)


### PR DESCRIPTION
https://github.com/jump-dev/jump-dev.github.io/pull/118 broken pre-existing links because it added a `[general]` category, resulting in https://jump.dev/general/2023/07/20/gams-blog/

This PR restores the old link: https://jump.dev/2023/07/20/gams-blog/