### PR TITLE
Fix CSS in JuMP-dev 2024 schedule

### DIFF
--- a/_includes/jump-dev-2024-schedule.html
+++ b/_includes/jump-dev-2024-schedule.html
@@ -13,13 +13,13 @@
 </tr>
 <tr>
   <td class="talk-table">09:00&nbsp;</td>
-  <td class="talk-table talk-long"><div class="talk-title">The state of JuMP</div><div class="talk-speaker">Miles Lubin</div></td>
+  <td class="talk-table"><div class="talk-title">The state of JuMP</div><div class="talk-speaker">Miles Lubin</div></td>
   <td class="talk-table"><div class="talk-title">Accelerating Automatic Differentiation with InfiniteExaModels.jl</div><div class="talk-speaker">Joshua Pulsipher</div></td>
   <td class="talk-table"></td>
 </tr>
 <tr>
   <td class="talk-table">09:15&nbsp;</td>
-  <td class="talk-table talk-long"></td>
+  <td class="talk-table"></td>
   <td class="talk-table"></td>
   <td class="talk-table"></td>
 </tr>
@@ -61,13 +61,13 @@
 </tr>
 <tr>
   <td class="talk-table">11:00&nbsp;</td>
-  <td class="talk-table talk-long"><div class="talk-title">Applied optimization with JuMP at SINTEF</div><div class="talk-speaker">Truls Flatberg</div></td>
+  <td class="talk-table"><div class="talk-title">Applied optimization with JuMP at SINTEF</div><div class="talk-speaker">Truls Flatberg</div></td>
   <td class="talk-table"><div class="talk-title">Invited talk: Unifying nonlinearly constrained nonconvex optimization</div><div class="talk-speaker">Charlie Vanaret</div></td>
   <td class="talk-table talk-organization"></td>
 </tr>
 <tr>
   <td class="talk-table">11:15&nbsp;</td>
-  <td class="talk-table talk-long"></td>
+  <td class="talk-table"></td>
   <td class="talk-table"></td>
   <td class="talk-table talk-organization"></td>
 </tr>
@@ -85,13 +85,13 @@
 </tr>
 <tr>
   <td class="talk-table">12:00&nbsp;</td>
-  <td class="talk-table talk-long"><div class="talk-title">Solving the Market-to-Market Problem in Large Scale Power Systems</div><div class="talk-speaker">Jose Daniel Lara</div></td>
+  <td class="talk-table"><div class="talk-title">Solving the Market-to-Market Problem in Large Scale Power Systems</div><div class="talk-speaker">Jose Daniel Lara</div></td>
   <td class="talk-table"><div class="talk-title">The New DisjunctiveProgramming.jl</div><div class="talk-speaker">Joshua Pulsipher</div></td>
   <td class="talk-table talk-organization"></td>
 </tr>
 <tr>
   <td class="talk-table">12:15&nbsp;</td>
-  <td class="talk-table talk-long"></td>
+  <td class="talk-table"></td>
   <td class="talk-table"><div class="talk-title">PiecewiseAffineApprox.jl</div><div class="talk-speaker">Lars Hellemo</div></td>
   <td class="talk-table talk-organization"></td>
 </tr>

--- a/assets/jump-dev-workshops/2024/schedule.toml
+++ b/assets/jump-dev-workshops/2024/schedule.toml
@@ -10,10 +10,8 @@ type = "organization"
 [talks.1_09_00]
 speaker = "Miles Lubin"
 title = "The state of JuMP"
-type = "long"
 
 [talks.1_09_15]
-type = "long"
 
 [talks.1_09_30]
 speaker = "Andrew Rosemberg"
@@ -42,10 +40,8 @@ type = "break"
 [talks.1_11_00]
 speaker = "Truls Flatberg"
 title = "Applied optimization with JuMP at SINTEF"
-type = "long"
 
 [talks.1_11_15]
-type = "long"
 
 [talks.1_11_30]
 speaker = "Ni Wang"
@@ -58,10 +54,8 @@ title = "SpineOpt.jl: A highly adaptable modelling framework for multi-energy sy
 [talks.1_12_00]
 speaker = "Jose Daniel Lara"
 title = "Solving the Market-to-Market Problem in Large Scale Power Systems"
-type = "long"
 
 [talks.1_12_15]
-type = "long"
 
 [talks.1_12_30]
 title = "Lunch"

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -12,7 +12,24 @@ $linkColour: $julia_green;
 
 $colour-notification-banner: #ffc107;
 
+.talk-table {
+  padding: 5px;
+  vertical-align: top;
+}
+
+.talk-break {
+  background-color: #CB3C3333;
+}
+
+.talk-organization {
+  background-color: #9558B233;
+}
+
 @import "alembic";
+
+.talk-speaker {
+  color: $captionColour;
+}
 
 .typeset pre {
   line-height: 1rem;
@@ -135,27 +152,4 @@ $colour-notification-banner: #ffc107;
     width: max-content;
     background: $backgroundColour;
   }
-}
-
-
-.talk-table {
-  padding: 5px;
-  vertical-align: top;
-}
-
-// .talk-long {
-//   vertical-align: top;
-//   background-color: #38982633;
-// }
-
-.talk-break {
-  background-color: #CB3C3333;
-}
-
-.talk-organization {
-  background-color: #9558B233;
-}
-
-.talk-speaker {
-  color: $captionColour;
 }


### PR DESCRIPTION
This works locally, so I don't know what's going on

<img width="992" alt="image" src="https://github.com/jump-dev/jump-dev.github.io/assets/8177701/f4f5dfe1-c731-4e37-94b3-353b57190480">
