### PR TITLE
Add announcement for LANL's AI project

### DIFF
--- a/_posts/2024-09-01-lanl.md
+++ b/_posts/2024-09-01-lanl.md
@@ -11,7 +11,7 @@ to announce that we, through [NumFOCUS](https://numfocus.org), have signed an
 agreement with [Los Alamos National Laboratory (LANL)](https://www.lanl.gov) to
 develop an AI toolbox for JuMP.
 
-The main deliverable is a new package, `MathOptAI.jl` which is a package for
+The main deliverable is a new package, `MathOptAI.jl`, which is a package for
 embedding trained machine learning predictors into a JuMP model. MathOptAI is
 inspired by packages such as
 [gurobi-machinelearning](https://github.com/Gurobi/gurobi-machinelearning)

--- a/_posts/2024-09-01-lanl.md
+++ b/_posts/2024-09-01-lanl.md
@@ -1,0 +1,35 @@
+---
+layout: post
+title:  "NumFOCUS signs agreement with LANL to develop and support an AI toolbox for JuMP"
+date:   2024-09-01
+categories: [announcements]
+author: "Miles Lubin, Julia Hall, and Changhyun Kwon"
+---
+
+The [JuMP Steering Committee](/pages/governance/#steering-committee) is pleased
+to announce that we, through [NumFOCUS](https://numfocus.org), have signed an
+agreement with [Los Alamos National Laboratory (LANL)](https://www.lanl.gov) to
+develop an AI toolbox for JuMP.
+
+The main deliverable is a new package, `MathOptAI.jl` which is a package for
+embedding trained machine learning predictors into a JuMP model. MathOptAI is
+inspired by packages such as
+[gurobi-machinelearning](https://github.com/Gurobi/gurobi-machinelearning)
+and [OMLT](https://github.com/cog-imperial/OMLT). (We will update this post with
+a link to MathOptAI once it is public.)
+
+A second deliverable is to develop a toolbox for creating, deploying, managing,
+and analyzing computational experiments related to JuMP on LANL's HPC clusters.
+The goal of this task is to simplify experiments such as Carleton Coffrin's
+[AC-OPF benchmark](https://discourse.julialang.org/t/ac-optimal-power-flow-in-various-nonlinear-optimization-frameworks/78486).
+
+As a third deliverable, we will provide general support for LANL staff and their
+project partners on JuMP and Julia for AI.
+
+The agreement runs until September 2026, and the person being funded is
+[Dr. Oscar Dowson](https://github.com/odow), a core contributor to JuMP, and
+also a member of the Steering Committee.
+
+(Per our [conflict of interest policy](/pages/governance/#conflict-of-interest),
+Oscar, who is funded by the grant, and Carleton, who works at LANL, recused
+themselves from Steering Committee votes on this agreement.)

--- a/_posts/2024-09-01-lanl.md
+++ b/_posts/2024-09-01-lanl.md
@@ -3,7 +3,7 @@ layout: post
 title:  "NumFOCUS signs agreement with LANL to develop and support an AI toolbox for JuMP"
 date:   2024-09-01
 categories: [announcements]
-author: "Miles Lubin, Julia Hall, and Changhyun Kwon"
+author: "Miles Lubin, Julian Hall, and Changhyun Kwon"
 ---
 
 The [JuMP Steering Committee](/pages/governance/#steering-committee) is pleased


### PR DESCRIPTION
I'm still waiting on permission to make https://github.com/lanl-ansi/MathOptAI.jl public.
