### PR TITLE
Add a talk on MOI to JuMP-dev 2025

### DIFF
--- a/_includes/jump-dev-2025-schedule.html
+++ b/_includes/jump-dev-2025-schedule.html
@@ -97,7 +97,7 @@
 <tr>
   <td class="talk-table">14:00&nbsp;</td>
   <td class="talk-table"><div class="talk-title">Automatic Generation of JuMP.jl Constraints from ModelingToolkit.jl Models</div><div class="talk-speaker">Dimitri Alston</div></td>
-  <td class="talk-table"><div class="talk-title">Revisiting sparse matrix coloring and bicoloring</div><div class="talk-speaker">Alexis Montoison</div></td>
+  <td class="talk-table"><div class="talk-title">What's new in HiGHS, and thanks to JuMP for its support!</div><div class="talk-speaker">Julian Hall</div></td>
 </tr>
 <tr>
   <td class="talk-table">14:15&nbsp;</td>
@@ -107,7 +107,7 @@
 <tr>
   <td class="talk-table">14:30&nbsp;</td>
   <td class="talk-table"><div class="talk-title">Large Scale JuMP Models with Constraint Generators</div><div class="talk-speaker">Benoît Legat</div></td>
-  <td class="talk-table"><div class="talk-title">Open energy models: benchmarking, profiling and debugging tool for JuMP</div><div class="talk-speaker">Joaquim Dias Garcia</div></td>
+  <td class="talk-table"><div class="talk-title">Revisiting sparse matrix coloring and bicoloring</div><div class="talk-speaker">Alexis Montoison</div></td>
 </tr>
 <tr>
   <td class="talk-table">14:45&nbsp;</td>
@@ -127,25 +127,35 @@
 <tr>
   <td class="talk-table">15:30&nbsp;</td>
   <td class="talk-table"><div class="talk-title">The State of InfiniteOpt.jl</div><div class="talk-speaker">Joshua Pulsipher</div></td>
-  <td class="talk-table"><div class="talk-title">TIMES2JuMP -  Learnings from IEA-ETSAP feasibility study of migrating the TIMES code to Julia JuMP.</div><div class="talk-speaker">James Glynn</div></td>
+  <td class="talk-table"><div class="talk-title">Open energy models: benchmarking, profiling and debugging tool for JuMP</div><div class="talk-speaker">Joaquim Dias Garcia</div></td>
 </tr>
 <tr>
   <td class="talk-table">15:45&nbsp;</td>
   <td class="talk-table"></td>
-  <td class="talk-table"><div class="talk-title">Lessons from using JuMP in HARD software</div><div class="talk-speaker">Harley Mackenzie</div></td>
+  <td class="talk-table"></td>
 </tr>
 <tr>
   <td class="talk-table">16:00&nbsp;</td>
-  <td class="talk-table"><div class="talk-title">What's new in HiGHS, and thanks to JuMP for its support!</div><div class="talk-speaker">Julian Hall</div></td>
-  <td class="talk-table"><div class="talk-title">The life and times of SDDP.jl</div><div class="talk-speaker">Oscar Dowson</div></td>
+  <td class="talk-table"><div class="talk-title">MathOptInterface: a comprehensive overview</div><div class="talk-speaker">Oscar Dowson</div></td>
+  <td class="talk-table"><div class="talk-title">TIMES2JuMP -  Learnings from IEA-ETSAP feasibility study of migrating the TIMES code to Julia JuMP.</div><div class="talk-speaker">James Glynn</div></td>
 </tr>
 <tr>
   <td class="talk-table">16:15&nbsp;</td>
   <td class="talk-table"></td>
-  <td class="talk-table"></td>
+  <td class="talk-table"><div class="talk-title">Lessons from using JuMP in HARD software</div><div class="talk-speaker">Harley Mackenzie</div></td>
 </tr>
 <tr>
   <td class="talk-table">16:30&nbsp;</td>
+  <td class="talk-table"></td>
+  <td class="talk-table"><div class="talk-title">The life and times of SDDP.jl</div><div class="talk-speaker">Oscar Dowson</div></td>
+</tr>
+<tr>
+  <td class="talk-table">16:45&nbsp;</td>
+  <td class="talk-table"></td>
+  <td class="talk-table"></td>
+</tr>
+<tr>
+  <td class="talk-table">17:00&nbsp;</td>
   <td class="talk-table talk-organization"><div class="talk-title">Wrap up</div></td>
   <td class="talk-table talk-organization"><div class="talk-title">Wrap up and thanks</div></td>
 </tr>

--- a/assets/jump-dev-workshops/2025/schedule.toml
+++ b/assets/jump-dev-workshops/2025/schedule.toml
@@ -89,12 +89,16 @@ title = "The State of InfiniteOpt.jl"
 [talks.1_15_45]
 
 [talks.1_16_00]
-speaker = "Julian Hall"
-title = "What's new in HiGHS, and thanks to JuMP for its support!"
+speaker = "Oscar Dowson"
+title = "MathOptInterface: a comprehensive overview"
 
 [talks.1_16_15]
 
 [talks.1_16_30]
+
+[talks.1_16_45]
+
+[talks.1_17_00]
 title = "Wrap up"
 type = "organization"
 
@@ -155,14 +159,14 @@ type = "break"
 type = "break"
 
 [talks.2_14_00]
-speaker = "Alexis Montoison"
-title = "Revisiting sparse matrix coloring and bicoloring"
+speaker = "Julian Hall"
+title = "What's new in HiGHS, and thanks to JuMP for its support!"
 
 [talks.2_14_15]
 
 [talks.2_14_30]
-speaker = "Joaquim Dias Garcia"
-title = "Open energy models: benchmarking, profiling and debugging tool for JuMP"
+speaker = "Alexis Montoison"
+title = "Revisiting sparse matrix coloring and bicoloring"
 
 [talks.2_14_45]
 
@@ -174,19 +178,25 @@ type = "break"
 type = "break"
 
 [talks.2_15_30]
+speaker = "Joaquim Dias Garcia"
+title = "Open energy models: benchmarking, profiling and debugging tool for JuMP"
+
+[talks.2_15_45]
+
+[talks.2_16_00]
 speaker = "James Glynn"
 title = "TIMES2JuMP -  Learnings from IEA-ETSAP feasibility study of migrating the TIMES code to Julia JuMP."
 
-[talks.2_15_45]
+[talks.2_16_15]
 speaker = "Harley Mackenzie"
 title = "Lessons from using JuMP in HARD software"
 
-[talks.2_16_00]
+[talks.2_16_30]
 speaker = "Oscar Dowson"
 title = "The life and times of SDDP.jl"
 
-[talks.2_16_15]
+[talks.2_16_45]
 
-[talks.2_16_30]
+[talks.2_17_00]
 title = "Wrap up and thanks"
 type = "organization"


### PR DESCRIPTION
We discussed on today's developer call that it would be good to have a proper talk on MOI so that we can reference it for posterity.

I've scheduled myself 1 hr, because there is a lot we could speak about and I think we'll need more than 30 minutes. If we finish early that's not the end of the world.

New afternoon schedule is:

<img width="841" height="747" alt="image" src="https://github.com/user-attachments/assets/c9d90b9a-d629-452b-9765-3d8661f583c5" />
